### PR TITLE
slack action: github api sometimes returns last status none

### DIFF
--- a/.github/actions/slack-on-upstream-job-failure/action.yml
+++ b/.github/actions/slack-on-upstream-job-failure/action.yml
@@ -18,16 +18,21 @@ inputs:
     required: true
 runs:
   using: "composite"
+  env:
+    NEEDS_STATUS: >-
+      ${{
+        contains(fromJson(inputs.needs-context).*.result, 'failure') && 'failure'
+        || contains(fromJson(inputs.needs-context).*.result, 'cancelled') && 'cancelled'
+        || 'success'
+      }}
   steps:
     - name: Get branch names
       id: branch-name
       uses: tj-actions/branch-names@v5.1
-    - name: Determine if notification is needed
-      uses: Jimdo/should-i-notify-action@d27f60fd66e60ee85b27d0a9bdf4b5fcd2abd52e
-      id: should_notify
+    - name: Get previous workflow status
+      uses: Mercymeilya/last-workflow-status@v0.3
+      id: last_status
       with:
-        branch: ${{ steps.branch-name.outputs.current_branch }}
-        needs_context: ${{ inputs.needs-context }}
         github_token: ${{ inputs.github-token }}
     - uses: actions/checkout@v2
       with:
@@ -38,15 +43,9 @@ runs:
       run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
     - name: Post to Slack App
       id: slack-app-post
-      if: ${{ steps.should_notify.outputs.should_send_message == 'yes' }}
+      if: ${{ (steps.last_status.outputs.last_status != 'success') || (env.NEEDS_STATUS != 'success') }}
       uses: slackapi/slack-github-action@v1.16.0
       env:
-        STATUS: >-
-          ${{
-            contains(fromJson(inputs.needs-context).*.result, 'failure') && 'failure'
-            || contains(fromJson(inputs.needs-context).*.result, 'cancelled') && 'cancelled'
-            || 'success'
-          }}
         SLACK_BOT_TOKEN: ${{ inputs.slack-bot-token }}
         WORKFLOW_RUN: >-
           ${{
@@ -87,14 +86,14 @@ runs:
             "icon_url": "${{ inputs.slack-icon-url}}",
             "attachments": [
               {
-                "fallback": "${{ github.repository }}@${{ steps.branch-name.outputs.current_branch }} ${{ github.workflow }} ${{ env.STATUS }}",
-                "color": "${{ env.STATUS == 'success' && '#2EB67D' || (env.STATUS == 'failure' && '#E01E5A' || '#ECB22E') }}",
+                "fallback": "${{ github.repository }}@${{ steps.branch-name.outputs.current_branch }} ${{ github.workflow }} ${{ env.NEEDS_STATUS }}",
+                "color": "${{ env.NEEDS_STATUS == 'success' && '#2EB67D' || (env.NEEDS_STATUS == 'failure' && '#E01E5A' || '#ECB22E') }}",
                 "blocks": [
                   {
                     "type": "section",
                     "text": {
                       "type": "mrkdwn",
-                      "text": "${{env.WORKFLOW_RUN}} ${{ env.STATUS }} ${{env.PULL_REQUEST}}"
+                      "text": "${{env.WORKFLOW_RUN}} ${{ env.NEEDS_STATUS }} ${{env.PULL_REQUEST}}"
                     }
                   },
                   {

--- a/.github/actions/slack-on-upstream-job-failure/action.yml
+++ b/.github/actions/slack-on-upstream-job-failure/action.yml
@@ -18,13 +18,6 @@ inputs:
     required: true
 runs:
   using: "composite"
-  env:
-    NEEDS_STATUS: >-
-      ${{
-        contains(fromJson(inputs.needs-context).*.result, 'failure') && 'failure'
-        || contains(fromJson(inputs.needs-context).*.result, 'cancelled') && 'cancelled'
-        || 'success'
-      }}
   steps:
     - name: Get branch names
       id: branch-name
@@ -40,12 +33,28 @@ runs:
     - name: Get short SHA
       id: vars
       shell: bash
-      run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+      run: |
+        LAST_STATUS=${{ steps.last_status.outputs.last_status }}
+        CURRENT_STATUS=${{
+          contains(fromJson(inputs.needs-context).*.result, 'failure') && 'failure'
+          || contains(fromJson(inputs.needs-context).*.result, 'cancelled') && 'cancelled'
+          || 'success'
+        }}
+        SHORT_SHA=$(git rev-parse --short HEAD)
+
+        echo "last workflow status: $LAST_STATUS"
+        echo "current workflow status: $CURRENT_STATUS"
+        echo "short SHA: $SHORT_SHA"
+
+        echo "::set-output name=last-run-status::$LAST_STATUS"
+        echo "::set-output name=this-run-status::$CURRENT_STATUS"
+        echo "::set-output name=sha_short::$SHORT_SHA"
     - name: Post to Slack App
       id: slack-app-post
-      if: ${{ (steps.last_status.outputs.last_status != 'success') || (env.NEEDS_STATUS != 'success') }}
+      if: ${{ (steps.vars.outputs.last-run-status != 'success') || (steps.vars.outputs.this-run-status != 'success') }}
       uses: slackapi/slack-github-action@v1.16.0
       env:
+        STATUS:${{ steps.vars.outputs.this-run-status }}
         SLACK_BOT_TOKEN: ${{ inputs.slack-bot-token }}
         WORKFLOW_RUN: >-
           ${{
@@ -86,14 +95,14 @@ runs:
             "icon_url": "${{ inputs.slack-icon-url}}",
             "attachments": [
               {
-                "fallback": "${{ github.repository }}@${{ steps.branch-name.outputs.current_branch }} ${{ github.workflow }} ${{ env.NEEDS_STATUS }}",
-                "color": "${{ env.NEEDS_STATUS == 'success' && '#2EB67D' || (env.NEEDS_STATUS == 'failure' && '#E01E5A' || '#ECB22E') }}",
+                "fallback": "${{ github.repository }}@${{ steps.branch-name.outputs.current_branch }} ${{ github.workflow }} ${{ env.STATUS }}",
+                "color": "${{ env.STATUS == 'success' && '#2EB67D' || (env.STATUS == 'failure' && '#E01E5A' || '#ECB22E') }}",
                 "blocks": [
                   {
                     "type": "section",
                     "text": {
                       "type": "mrkdwn",
-                      "text": "${{env.WORKFLOW_RUN}} ${{ env.NEEDS_STATUS }} ${{env.PULL_REQUEST}}"
+                      "text": "${{env.WORKFLOW_RUN}} ${{ env.STATUS }} ${{env.PULL_REQUEST}}"
                     }
                   },
                   {

--- a/.github/actions/slack-on-upstream-job-failure/action.yml
+++ b/.github/actions/slack-on-upstream-job-failure/action.yml
@@ -54,7 +54,7 @@ runs:
       if: ${{ (steps.vars.outputs.last-run-status != 'success') || (steps.vars.outputs.this-run-status != 'success') }}
       uses: slackapi/slack-github-action@v1.16.0
       env:
-        STATUS:${{ steps.vars.outputs.this-run-status }}
+        STATUS: ${{ steps.vars.outputs.this-run-status }}
         SLACK_BOT_TOKEN: ${{ inputs.slack-bot-token }}
         WORKFLOW_RUN: >-
           ${{


### PR DESCRIPTION
**EDIT:** https://github.community/t/bug-github-api-list-workflow-runs-returns-0-runs-even-though-there-are-runs/165080
**EDIT 2:** Seems like this is due to an ongoing github issue... good to know I am not crazy :) [See here](https://github.com/github/feedback/discussions/14871) and [here](https://github.community/t/filtering-workflow-runs-does-not-include-runs-created-in-the-last-6-hours/244282?u=gustavo-salazar)

Seems like the action we are using sometimes returns no workflows when doing requests with the "branch"-URL-parameter to the github api. Not sure why, as this works fine with other repositories, but one theory is that it affects workflows which do not exist on the github "default branch". The pictures below are from a pull request which implements a new Github Actions Workflow.

![Screenshot 2022-04-13 at 18 03 16](https://user-images.githubusercontent.com/4941926/163222671-f12c6584-047d-4426-bac1-87cefadcd2d7.png)

![Screenshot 2022-04-13 at 18 04 17](https://user-images.githubusercontent.com/4941926/163222765-db06155a-a259-4d5f-81dd-aec1487f79bd.png)

